### PR TITLE
Add Fixed Fee Plugin with cost calculation banner

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,9 +2,12 @@
 
 const CURSOR_KEY = "cursorFixEnabled";            // existing toggle
 const CURSOR_LINE_KEY = "cursorLineEnabled";      // NEW toggle (default ON)
+const FIXED_FEE_KEY = "fixedFeeEnabled";          // Fixed Fee Plugin toggle (default OFF)
 const CURSOR_CSS_FILE = "cursor-fix.css";
 const CURSOR_LINE_ON_FILE = "cursor-line-on.js";
 const CURSOR_LINE_OFF_FILE = "cursor-line-off.js";
+const FIXED_FEE_CSS_FILE = "fixed-fee-banner.css";
+const FIXED_FEE_JS_FILE = "fixed-fee-banner.js";
 
 // --- Helpers: get setting with default=true and persist if missing ---
 function getEnabledDefaultTrue(key) {
@@ -20,11 +23,26 @@ function getEnabledDefaultTrue(key) {
   });
 }
 
+// --- Helper: get setting with default=false and persist if missing ---
+function getEnabledDefaultFalse(key) {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(key, (res) => {
+      const val = res?.[key];
+      if (typeof val === "undefined") {
+        chrome.storage.sync.set({ [key]: false }, () => resolve(false));
+      } else {
+        resolve(!!val);
+      }
+    });
+  });
+}
+
 // Seed defaults on install/update (nice-to-have)
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.sync.get([CURSOR_KEY, CURSOR_LINE_KEY], (res) => {
+  chrome.storage.sync.get([CURSOR_KEY, CURSOR_LINE_KEY, FIXED_FEE_KEY], (res) => {
     if (typeof res[CURSOR_KEY] === "undefined") chrome.storage.sync.set({ [CURSOR_KEY]: true });
     if (typeof res[CURSOR_LINE_KEY] === "undefined") chrome.storage.sync.set({ [CURSOR_LINE_KEY]: true });
+    if (typeof res[FIXED_FEE_KEY] === "undefined") chrome.storage.sync.set({ [FIXED_FEE_KEY]: false });
   });
 });
 
@@ -80,19 +98,49 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     });
     return true; // async
   }
+
+  // Fixed Fee Plugin state
+  if (msg?.type === "GET_FIXED_FEE_STATE") {
+    getEnabledDefaultFalse(FIXED_FEE_KEY).then((enabled) => sendResponse({ enabled }));
+    return true; // async
+  }
+  if (msg?.type === "SET_FIXED_FEE_STATE") {
+    const enabled = !!msg.enabled;
+    chrome.storage.sync.set({ [FIXED_FEE_KEY]: enabled }, async () => {
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab?.id) {
+          if (enabled) await insertFixedFeeBanner(tab.id);
+          else await removeFixedFeeBanner(tab.id);
+        }
+      } catch (e) {
+        console.error("Failed to toggle fixed fee banner:", e?.message || e);
+      } finally {
+        sendResponse({ ok: true });
+      }
+    });
+    return true; // async
+  }
 });
 
-// ---- Auto-apply on page load/refresh to /resourcing ----
+// ---- Auto-apply on page load/refresh ----
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status !== "complete" || !isResourcingUrl(tab?.url)) return;
+  if (changeInfo.status !== "complete") return;
 
-  // Apply both features according to settings (both default ON)
-  getEnabledDefaultTrue(CURSOR_KEY).then((enabled) => {
-    if (enabled) insertCursorCss(tabId).catch((e) => console.error("insert CSS:", e?.message || e));
-  });
+  // Apply /resourcing features
+  if (isResourcingUrl(tab?.url)) {
+    getEnabledDefaultTrue(CURSOR_KEY).then((enabled) => {
+      if (enabled) insertCursorCss(tabId).catch((e) => console.error("insert CSS:", e?.message || e));
+    });
 
-  getEnabledDefaultTrue(CURSOR_LINE_KEY).then((enabled) => {
-    if (enabled) insertCursorLine(tabId).catch((e) => console.error("insert line:", e?.message || e));
+    getEnabledDefaultTrue(CURSOR_LINE_KEY).then((enabled) => {
+      if (enabled) insertCursorLine(tabId).catch((e) => console.error("insert line:", e?.message || e));
+    });
+  }
+
+  // Apply Fixed Fee Plugin (works on all pages)
+  getEnabledDefaultFalse(FIXED_FEE_KEY).then((enabled) => {
+    if (enabled) insertFixedFeeBanner(tabId).catch((e) => console.error("insert fixed fee:", e?.message || e));
   });
 });
 
@@ -124,6 +172,31 @@ async function insertCursorLine(tabId) {
 async function removeCursorLine(tabId) {
   if (!chrome.scripting?.executeScript) throw new Error("scripting.executeScript unavailable");
   await chrome.scripting.executeScript({ target: { tabId, allFrames: true }, files: [CURSOR_LINE_OFF_FILE] });
+}
+
+async function insertFixedFeeBanner(tabId) {
+  if (!chrome.scripting?.insertCSS || !chrome.scripting?.executeScript) {
+    throw new Error("scripting APIs unavailable");
+  }
+  await chrome.scripting.insertCSS({ target: { tabId }, files: [FIXED_FEE_CSS_FILE] });
+  await chrome.scripting.executeScript({ target: { tabId }, files: [FIXED_FEE_JS_FILE] });
+}
+
+async function removeFixedFeeBanner(tabId) {
+  if (!chrome.scripting?.removeCSS || !chrome.scripting?.executeScript) {
+    throw new Error("scripting APIs unavailable");
+  }
+  await chrome.scripting.executeScript({ 
+    target: { tabId }, 
+    func: () => {
+      if (window.kantataFixedFeeCleanup) {
+        window.kantataFixedFeeCleanup();
+      }
+      const banner = document.getElementById('kantata-fixed-fee-banner');
+      if (banner) banner.remove();
+    }
+  });
+  await chrome.scripting.removeCSS({ target: { tabId }, files: [FIXED_FEE_CSS_FILE] });
 }
 
 // ======= Existing feature: Click all "Toggle User" buttons =======

--- a/background_old.js
+++ b/background_old.js
@@ -1,0 +1,169 @@
+// background.js
+
+const CURSOR_KEY = "cursorFixEnabled";
+const CURSOR_CSS_FILE = "cursor-fix.css";
+
+// --- Helper: read setting with default=true and persist if missing ---
+function getCursorFixEnabledDefaultTrue() {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(CURSOR_KEY, (res) => {
+      const val = res?.[CURSOR_KEY];
+      if (typeof val === "undefined") {
+        // Seed default ON and return true
+        chrome.storage.sync.set({ [CURSOR_KEY]: true }, () => resolve(true));
+      } else {
+        resolve(!!val);
+      }
+    });
+  });
+}
+
+// Keep this (nice-to-have) seeding on install/update
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.sync.get(CURSOR_KEY, (res) => {
+    if (typeof res[CURSOR_KEY] === "undefined") {
+      chrome.storage.sync.set({ [CURSOR_KEY]: true });
+    }
+  });
+});
+
+// ---- Messages from popup ----
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg?.type === "CLICK_TOGGLE_USERS") {
+    runClickAll().finally(() => sendResponse({ ok: true }));
+    return true; // async
+  }
+
+  if (msg?.type === "GET_CURSOR_FIX_STATE") {
+    getCursorFixEnabledDefaultTrue().then((enabled) => sendResponse({ enabled }));
+    return true; // async
+  }
+
+  if (msg?.type === "SET_CURSOR_FIX_STATE") {
+    const enabled = !!msg.enabled;
+    chrome.storage.sync.set({ [CURSOR_KEY]: enabled }, async () => {
+      try {
+        const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+        if (tab?.id && isResourcingUrl(tab.url)) {
+          if (enabled) await insertCursorCss(tab.id);
+          else await removeCursorCss(tab.id);
+        }
+      } catch (e) {
+        console.error("Failed to toggle cursor CSS:", e?.message || e);
+      } finally {
+        sendResponse({ ok: true });
+      }
+    });
+    return true; // async
+  }
+});
+
+// ---- Auto-apply on navigation to /resourcing ----
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== "complete" || !isResourcingUrl(tab?.url)) return;
+
+  // DEFAULT TRUE even if storage was empty
+  getCursorFixEnabledDefaultTrue().then((enabled) => {
+    if (enabled) {
+      insertCursorCss(tabId).catch((e) =>
+        console.error("Failed to insert cursor CSS:", e?.message || e)
+      );
+    }
+  });
+});
+
+// ---- Helpers ----
+function isResourcingUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.pathname.toLowerCase().includes("/resourcing");
+  } catch {
+    return false;
+  }
+}
+
+async function insertCursorCss(tabId) {
+  if (!chrome.scripting?.insertCSS) throw new Error("scripting.insertCSS unavailable");
+  await chrome.scripting.insertCSS({
+    target: { tabId, allFrames: true },
+    files: [CURSOR_CSS_FILE]
+  });
+}
+
+async function removeCursorCss(tabId) {
+  if (!chrome.scripting?.removeCSS) throw new Error("scripting.removeCSS unavailable");
+  await chrome.scripting.removeCSS({
+    target: { tabId, allFrames: true },
+    files: [CURSOR_CSS_FILE]
+  });
+}
+
+// =================== FEATURE: CLICK_TOGGLE_USERS Click all "Toggle User" buttons ==============================
+
+/**
+ * Orchestrates script injection from the background worker.
+ */
+async function runClickAll() {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id) throw new Error("No active tab found.");
+
+    // Guard: if scripting API isn't available, fail gracefully instead of TypeError
+    if (!chrome.scripting || typeof chrome.scripting.executeScript !== "function") {
+      console.error("chrome.scripting API is unavailable. Reload the extension and ensure Chrome 88+ with Manifest V3.");
+      return;
+    }
+
+    // Inject into all accessible frames
+    const results = await chrome.scripting.executeScript({
+      target: { tabId: tab.id, allFrames: true },
+      world: "MAIN",
+      func: clickAllToggleUserButtons
+    });
+
+    const totalFound = results?.reduce((sum, r) => sum + (r?.result?.found || 0), 0) || 0;
+    const totalClicked = results?.reduce((sum, r) => sum + (r?.result?.clicked || 0), 0) || 0;
+
+    // If nothing was found anywhere, also emit the required error once from the extension side
+    if (totalFound === 0 || totalClicked === 0) {
+      console.error("No buttons with aria-label='Toggle User' and title='Toggle User' found.");
+    }
+  } catch (err) {
+    console.error("Error executing action on this page:", err?.message || err);
+  }
+}
+
+/**
+ * Runs in the page context. Finds and clicks all matching buttons,
+ * logging the required success/error messages to the page console.
+ */
+function clickAllToggleUserButtons() {
+  try {
+    const selector = 'button[aria-label="Toggle User"][title="Toggle User"]';
+    const buttons = Array.from(document.querySelectorAll(selector));
+
+    if (buttons.length === 0) {
+      if (window.top === window) {
+        console.error("No buttons with aria-label='Toggle User' and title='Toggle User' found.");
+      }
+      return { found: 0, clicked: 0 };
+    }
+
+    // Click all in the same frame tick (as simultaneously as possible)
+    requestAnimationFrame(() => {
+      for (const btn of buttons) {
+        try {
+          btn.click();
+          console.log("Button with aria-label='Toggle User' clicked.");
+        } catch (clickErr) {
+          console.error("Error clicking a 'Toggle User' button:", clickErr);
+        }
+      }
+    });
+
+    return { found: buttons.length, clicked: buttons.length };
+  } catch (err) {
+    console.error("Unexpected error while finding/clicking buttons:", err);
+    return { found: 0, clicked: 0 };
+  }
+}

--- a/feature_designs/01_project-overview-estimate-calculator
+++ b/feature_designs/01_project-overview-estimate-calculator
@@ -1,0 +1,166 @@
+# Technical Requirements Document: Activate Fixed Fee Plugin
+
+## 1. Overview
+This Chrome extension feature adds a persistent banner that displays project cost calculations with adjustable margin percentages for project management interfaces.
+
+## 2. Feature Toggle
+
+### 2.1 Plugin Settings
+- **Requirement**: Add checkbox in Chrome extension popup menu
+- **Label**: "Activate Fixed Fee Plugin"
+- **Behavior**: 
+  - Checked = Feature active, banner visible
+  - Unchecked = Feature inactive, banner hidden
+- **Default State**: Unchecked
+
+## 3. Banner Implementation
+
+### 3.1 Banner Positioning & Styling
+- **Position**: Fixed at top of browser viewport
+- **Z-index**: High value to ensure visibility above all page content
+- **Background**: Bright orange color theme
+- **Width**: Full viewport width
+- **Height**: Auto-adjust to content
+- **Layout**: Horizontal arrangement of elements
+
+### 3.2 Banner Visibility
+- **Show Condition**: Plugin checkbox is enabled
+- **Hide Condition**: Plugin checkbox is disabled
+- **Persistence**: Always visible when enabled (no dismiss option)
+
+## 4. Data Extraction
+
+### 4.1 Source Element Detection
+- **Target Element**: Div containing "Est. Cost" with dynamic class names
+- **Selection Strategy**: Use `data-testid` attribute for reliability:
+  ```html
+  [data-testid="Total estimated cost (Resource Estimated Hours * Cost Rate) of named and unnamed resource assignments on this project."]
+  ```
+- **Fallback Strategy**: If testid unavailable, search for div containing "Est. Cost" header text
+
+### 4.2 Value Processing
+- **Extract From**: `.summary-bar_summary-item__content--[randomID]` child element
+- **Format Conversion**: 
+  - Remove `&nbsp;` characters
+  - Remove currency symbols (€, £, $)
+  - Remove thousand separators (spaces, commas)
+  - Convert to numeric value
+- **Currency Detection**: Preserve original currency symbol for display formatting
+
+### 4.3 Error Handling
+- **Missing Element**: Display "Cannot find the Estimated Cost on this page"
+- **Invalid Value**: Display "Unable to parse cost value"
+- **Network Issues**: Retry extraction after 2 seconds
+
+## 5. Banner Components
+
+### 5.1 Estimated Cost Display
+- **Label**: "Estimated Cost:"
+- **Value**: Extracted cost in original currency format
+- **Position**: Left side of banner
+- **Update Trigger**: Page load and DOM changes
+
+### 5.2 Percentage Input Control
+- **Type**: HTML number input with spinner controls
+- **Range**: -100% to +100%
+- **Default Value**: 45%
+- **Decimal Support**: Yes (e.g., 10.5%)
+- **Input Methods**:
+  - Manual text entry
+  - Increment/decrement buttons (step: 0.1%)
+  - Keyboard up/down arrows
+- **Position**: Center of banner
+- **Label**: "Margin %:"
+
+### 5.3 Calculated Fee Display
+- **Label**: "Estimated Fee with Margin:"
+- **Calculation**: `Estimated Cost × (1 + Percentage/100)`
+- **Rounding**: Round to nearest whole number
+- **Format**: Same currency format as original (symbol, thousand separators)
+- **Position**: Right side of banner
+- **Update Trigger**: Real-time as percentage changes
+
+## 6. Calculation Examples
+
+### Example 1: Positive Margin
+- **Estimated Cost**: 209,536 €
+- **Margin**: 10%
+- **Result**: 230,490 € (209,536 × 1.1 = 230,489.6, rounded to 230,490)
+
+### Example 2: Negative Margin
+- **Estimated Cost**: 209,536 €
+- **Margin**: -25%
+- **Result**: 157,152 € (209,536 × 0.75 = 157,152)
+
+## 7. Multi-Currency Support
+- **Supported Currencies**: Euro (€), British Pound (£), US Dollar ($)
+- **Detection Method**: Identify currency symbol in extracted value
+- **Display Consistency**: Maintain original currency symbol and formatting
+
+## 8. Technical Implementation Notes
+
+### 8.1 DOM Monitoring
+- **Observer**: MutationObserver to detect page changes
+- **Scope**: Monitor changes to cost summary section
+- **Performance**: Debounce updates to prevent excessive recalculation
+
+### 8.2 Data Persistence
+- **Session Scope**: No persistence between page loads
+- **Default Behavior**: Reset to 45% on each page load
+- **State Management**: Store current values in memory only
+
+### 8.3 Browser Compatibility
+- **Target**: Chrome extension manifest v3
+- **CSS**: Use standard CSS properties for broad compatibility
+- **JavaScript**: ES6+ features acceptable for Chrome extension context
+
+## 9. User Experience Requirements
+
+### 9.1 Visual Feedback
+- **Loading State**: Show "Loading..." while extracting cost data
+- **Error State**: Clear error messaging for extraction failures
+- **Real-time Updates**: Immediate calculation updates on percentage change
+
+### 9.2 Accessibility
+- **Keyboard Navigation**: All controls accessible via keyboard
+- **Screen Readers**: Proper labeling for assistive technologies
+- **Color Contrast**: Ensure text readability on orange background
+
+## 10. Testing Scenarios
+
+### 10.1 Functional Tests
+- [ ] Plugin toggle enables/disables banner
+- [ ] Cost extraction works with various number formats
+- [ ] Percentage input accepts valid range (-100% to +100%)
+- [ ] Calculation accuracy for positive and negative margins
+- [ ] Multi-currency support (€, £, $)
+- [ ] Error handling for missing cost elements
+
+### 10.2 Edge Cases
+- [ ] Very large cost values
+- [ ] Extreme percentage values (-100%, +100%)
+- [ ] Page navigation and banner persistence
+- [ ] Multiple tabs with different cost values
+- [ ] Rapid percentage changes (performance)
+
+## 11. Implementation Priority
+
+### Phase 1: Core Functionality
+1. Basic banner display
+2. Cost value extraction
+3. Percentage input control
+4. Calculation logic
+
+### Phase 2: Enhanced Features
+1. Multi-currency support
+2. Error handling
+3. Visual feedback states
+
+### Phase 3: Polish & Testing
+1. Accessibility improvements
+2. Performance optimization
+3. Comprehensive testing
+
+---
+
+*This technical requirements document provides the foundation for implementing the "Activate Fixed Fee Plugin" feature. Please review and confirm if any adjustments are needed before development begins.*

--- a/fixed-fee-banner.css
+++ b/fixed-fee-banner.css
@@ -1,0 +1,92 @@
+#kantata-fixed-fee-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  background: linear-gradient(135deg, #ff8c00 0%, #ff7f00 100%);
+  color: white;
+  z-index: 10000;
+  padding: 12px 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 20px;
+  box-sizing: border-box;
+}
+
+#kantata-fixed-fee-banner * {
+  box-sizing: border-box;
+}
+
+.fixed-fee-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+.fixed-fee-label {
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.fixed-fee-value {
+  font-weight: 700;
+  font-size: 16px;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.fixed-fee-input-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255,255,255,0.15);
+  padding: 8px 12px;
+  border-radius: 6px;
+  backdrop-filter: blur(10px);
+}
+
+#fixed-fee-percentage {
+  width: 80px;
+  padding: 6px 8px;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.9);
+  color: #333;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+}
+
+#fixed-fee-percentage:focus {
+  outline: 2px solid rgba(255,255,255,0.8);
+  outline-offset: 1px;
+  background: white;
+}
+
+.fixed-fee-error {
+  color: #ffeeee;
+  font-style: italic;
+  font-weight: normal;
+}
+
+.fixed-fee-loading {
+  color: #fff3cd;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  #kantata-fixed-fee-banner {
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 20px;
+  }
+  
+  .fixed-fee-section {
+    justify-content: center;
+  }
+}

--- a/fixed-fee-banner.js
+++ b/fixed-fee-banner.js
@@ -1,0 +1,236 @@
+(function() {
+  'use strict';
+
+  if (document.getElementById('kantata-fixed-fee-banner')) {
+    return;
+  }
+
+  let currentEstimatedCost = null;
+  let currentCurrency = '€';
+  let mutationObserver = null;
+
+  function createBanner() {
+    const banner = document.createElement('div');
+    banner.id = 'kantata-fixed-fee-banner';
+    banner.innerHTML = `
+      <div class="fixed-fee-section">
+        <span class="fixed-fee-label">Estimated Cost:</span>
+        <span class="fixed-fee-value" id="estimated-cost-display">Loading...</span>
+      </div>
+      <div class="fixed-fee-input-section">
+        <span class="fixed-fee-label">Margin %:</span>
+        <input type="number" id="fixed-fee-percentage" value="45" step="1">
+      </div>
+      <div class="fixed-fee-section">
+        <span class="fixed-fee-label">Estimated Fee with Margin:</span>
+        <span class="fixed-fee-value" id="calculated-fee-display">-</span>
+      </div>
+    `;
+
+    document.body.appendChild(banner);
+
+    const percentageInput = document.getElementById('fixed-fee-percentage');
+    percentageInput.addEventListener('input', calculateAndDisplayFee);
+    percentageInput.addEventListener('change', calculateAndDisplayFee);
+
+    adjustBodyMargin();
+    return banner;
+  }
+
+  function adjustBodyMargin() {
+    const banner = document.getElementById('kantata-fixed-fee-banner');
+    if (banner) {
+      const bannerHeight = banner.offsetHeight;
+      document.body.style.marginTop = `${bannerHeight}px`;
+    }
+  }
+
+  function extractEstimatedCost() {
+    let element = null;
+    let costText = null;
+
+    const testIdSelector = '[data-testid*="Total estimated cost"]';
+    element = document.querySelector(testIdSelector);
+    
+    if (!element) {
+      const allElements = document.querySelectorAll('*');
+      for (let el of allElements) {
+        if (el.textContent && el.textContent.includes('Est. Cost')) {
+          const parent = el.closest('div');
+          if (parent) {
+            const contentEl = parent.querySelector('[class*="summary-item__content"]');
+            if (contentEl) {
+              element = contentEl;
+              break;
+            }
+          }
+        }
+      }
+    } else {
+      const parent = element.closest('div');
+      if (parent) {
+        const contentEl = parent.querySelector('[class*="summary-item__content"]') || 
+                          parent.querySelector('[class*="content"]');
+        if (contentEl) {
+          element = contentEl;
+        }
+      }
+    }
+
+    if (!element) {
+      return { error: "Cannot find the Estimated Cost on this page" };
+    }
+
+    costText = element.textContent || element.innerText || '';
+    
+    if (!costText.trim()) {
+      return { error: "Unable to parse cost value" };
+    }
+
+    const currencyMatch = costText.match(/[€£$]/);
+    const currency = currencyMatch ? currencyMatch[0] : '€';
+
+    let cleanText = costText
+      .replace(/&nbsp;/g, ' ')
+      .replace(/[€£$]/g, '')
+      .replace(/[\s,]/g, '');
+
+    const numericValue = parseFloat(cleanText);
+    
+    if (isNaN(numericValue)) {
+      return { error: "Unable to parse cost value" };
+    }
+
+    return {
+      value: numericValue,
+      currency: currency,
+      originalText: costText.trim()
+    };
+  }
+
+  function formatCurrency(value, currency = '€') {
+    const rounded = Math.round(value);
+    const formatted = rounded.toLocaleString('en-US');
+    return `${formatted} ${currency}`;
+  }
+
+  function calculateAndDisplayFee() {
+    const percentageInput = document.getElementById('fixed-fee-percentage');
+    const calculatedDisplay = document.getElementById('calculated-fee-display');
+    
+    if (!currentEstimatedCost || !percentageInput || !calculatedDisplay) {
+      return;
+    }
+
+    const percentage = parseFloat(percentageInput.value) || 0;
+    const multiplier = 1 + (percentage / 100);
+    const calculatedFee = currentEstimatedCost * multiplier;
+    
+    calculatedDisplay.textContent = formatCurrency(calculatedFee, currentCurrency);
+  }
+
+  function updateEstimatedCost() {
+    const costDisplay = document.getElementById('estimated-cost-display');
+    if (!costDisplay) return;
+
+    const result = extractEstimatedCost();
+    
+    if (result.error) {
+      costDisplay.textContent = result.error;
+      costDisplay.className = 'fixed-fee-value fixed-fee-error';
+      currentEstimatedCost = null;
+      const calculatedDisplay = document.getElementById('calculated-fee-display');
+      if (calculatedDisplay) {
+        calculatedDisplay.textContent = '-';
+      }
+    } else {
+      currentEstimatedCost = result.value;
+      currentCurrency = result.currency;
+      costDisplay.textContent = formatCurrency(result.value, result.currency);
+      costDisplay.className = 'fixed-fee-value';
+      calculateAndDisplayFee();
+    }
+  }
+
+  function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+
+  function startMonitoring() {
+    if (mutationObserver) {
+      mutationObserver.disconnect();
+    }
+
+    const debouncedUpdate = debounce(updateEstimatedCost, 500);
+
+    mutationObserver = new MutationObserver((mutations) => {
+      let shouldUpdate = false;
+      
+      for (let mutation of mutations) {
+        if (mutation.type === 'childList' || 
+            (mutation.type === 'characterData' && 
+             mutation.target.textContent && 
+             (mutation.target.textContent.includes('€') || 
+              mutation.target.textContent.includes('£') || 
+              mutation.target.textContent.includes('$')))) {
+          shouldUpdate = true;
+          break;
+        }
+      }
+      
+      if (shouldUpdate) {
+        debouncedUpdate();
+      }
+    });
+
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
+  }
+
+  function cleanup() {
+    if (mutationObserver) {
+      mutationObserver.disconnect();
+      mutationObserver = null;
+    }
+    
+    const banner = document.getElementById('kantata-fixed-fee-banner');
+    if (banner) {
+      banner.remove();
+    }
+    
+    document.body.style.marginTop = '';
+  }
+
+  function init() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => {
+        setTimeout(() => {
+          createBanner();
+          updateEstimatedCost();
+          startMonitoring();
+        }, 1000);
+      });
+    } else {
+      setTimeout(() => {
+        createBanner();
+        updateEstimatedCost();
+        startMonitoring();
+      }, 1000);
+    }
+  }
+
+  window.kantataFixedFeeCleanup = cleanup;
+
+  init();
+})();

--- a/popup.html
+++ b/popup.html
@@ -214,6 +214,16 @@
             </div>
           </div>
         </div>
+
+        <div class="control-row">
+          <div class="control-icon">💰</div>
+          <div class="control-label">
+            <div class="checkbox-wrapper">
+              <input type="checkbox" id="fixedFeeToggle" />
+              <span style="margin-left: 8px;">Activate Fixed Fee Plugin</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,7 @@
 const btn = document.getElementById("btnClickToggleUsers");
 const cursorToggleCheckbox = document.getElementById("cursorToggle");
 const cursorLineCheckbox = document.getElementById("cursorLineCheckbox");
+const fixedFeeToggle = document.getElementById("fixedFeeToggle");
 
 // Click-all feature
 btn.addEventListener("click", async () => {
@@ -34,6 +35,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   } catch (e) {
     console.error("Failed to fetch cursor-line state:", e?.message || e);
   }
+
+  try {
+    const res3 = await chrome.runtime.sendMessage({ type: "GET_FIXED_FEE_STATE" });
+    fixedFeeToggle.checked = !!res3?.enabled; // default OFF
+  } catch (e) {
+    console.error("Failed to fetch fixed-fee state:", e?.message || e);
+  }
 });
 
 // Update on change (cursor-fix checkbox)
@@ -53,5 +61,15 @@ cursorLineCheckbox.addEventListener("change", async () => {
     await chrome.runtime.sendMessage({ type: "SET_CURSOR_LINE_STATE", enabled });
   } catch (e) {
     console.error("Failed to set cursor-line state:", e?.message || e);
+  }
+});
+
+// Update on change (fixed fee checkbox)
+fixedFeeToggle.addEventListener("change", async () => {
+  const enabled = fixedFeeToggle.checked;
+  try {
+    await chrome.runtime.sendMessage({ type: "SET_FIXED_FEE_STATE", enabled });
+  } catch (e) {
+    console.error("Failed to set fixed-fee state:", e?.message || e);
   }
 });

--- a/popup_old.html
+++ b/popup_old.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Toggle User Tools</title>
+    <meta name="color-scheme" content="light dark" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 12px;
+        width: 300px;
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      }
+      .wrap { display: grid; gap: 10px; }
+      h1 {
+        margin: 0 0 2px;
+        font-size: 14px;
+        font-weight: 600;
+      }
+      .hint {
+        font-size: 12px;
+        opacity: 0.7;
+      }
+      button#btnClickToggleUsers {
+        padding: 10px 12px;
+        border-radius: 8px;
+        border: 1px solid rgba(0,0,0,0.15);
+        background: transparent;
+        cursor: pointer;
+        font: inherit;
+      }
+      @media (prefers-color-scheme: dark) {
+        button#btnClickToggleUsers { border-color: rgba(255,255,255,0.2); }
+      }
+      button#btnClickToggleUsers:hover { background: rgba(0,0,0,0.05); }
+      @media (prefers-color-scheme: dark) {
+        button#btnClickToggleUsers:hover { background: rgba(255,255,255,0.06); }
+      }
+      button#btnClickToggleUsers:disabled { opacity: 0.6; cursor: not-allowed; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Actions</h1>
+      <button id="btnClickToggleUsers" type="button" aria-label='Click all "Toggle User" buttons'>
+        Click all "Toggle User" buttons
+      </button>
+      <div class="hint">Open DevTools to see console messages.</div>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup_old.js
+++ b/popup_old.js
@@ -1,0 +1,17 @@
+// popup.js
+const btn = document.getElementById("btnClickToggleUsers");
+
+btn.addEventListener("click", async () => {
+  const label = btn.textContent;
+  try {
+    btn.disabled = true;
+    btn.textContent = "Running…";
+    await chrome.runtime.sendMessage({ type: "CLICK_TOGGLE_USERS" });
+  } catch (err) {
+    console.error("Error sending message to background:", err?.message || err);
+  } finally {
+    btn.textContent = label;
+    btn.disabled = false;
+    window.close();
+  }
+});

--- a/popup_old_2.html
+++ b/popup_old_2.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Toggle User Tools</title>
+    <meta name="color-scheme" content="light dark" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 12px;
+        width: 300px;
+        font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      }
+      .wrap { display: grid; gap: 10px; }
+      h1 { margin: 0 0 2px; font-size: 14px; font-weight: 600; }
+      .hint { font-size: 12px; opacity: 0.7; }
+
+      button#btnClickToggleUsers {
+        padding: 10px 12px;
+        border-radius: 8px;
+        border: 1px solid rgba(0,0,0,0.15);
+        background: transparent;
+        cursor: pointer;
+        font: inherit;
+      }
+      @media (prefers-color-scheme: dark) {
+        button#btnClickToggleUsers { border-color: rgba(255,255,255,0.2); }
+      }
+      button#btnClickToggleUsers:hover { background: rgba(0,0,0,0.05); }
+      @media (prefers-color-scheme: dark) {
+        button#btnClickToggleUsers:hover { background: rgba(255,255,255,0.06); }
+      }
+      button#btnClickToggleUsers:disabled { opacity: 0.6; cursor: not-allowed; }
+
+      .row { display: grid; gap: 6px; }
+      label { font-size: 12px; opacity: 0.85; }
+      select#cursorToggle {
+        padding: 8px;
+        border-radius: 8px;
+        border: 1px solid rgba(0,0,0,0.15);
+        font: inherit;
+        background: transparent;
+      }
+      @media (prefers-color-scheme: dark) {
+        select#cursorToggle { border-color: rgba(255,255,255,0.2); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Actions</h1>
+
+      <button id="btnClickToggleUsers" type="button" aria-label='Click all "Toggle User" buttons'>
+        Click all "Toggle User" buttons
+      </button>
+
+      <div class="row">
+        <label for="cursorToggle">Disable hand cursor on <code>/resourcing</code></label>
+        <select id="cursorToggle" aria-label="Disable hand cursor on /resourcing">
+          <option value="on">On (default)</option>
+          <option value="off">Off</option>
+        </select>
+      </div>
+
+      <div class="hint">Console shows success/error messages.</div>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup_old_2.js
+++ b/popup_old_2.js
@@ -1,0 +1,39 @@
+// popup.js
+const btn = document.getElementById("btnClickToggleUsers");
+const selectCursor = document.getElementById("cursorToggle");
+
+// Click-all feature
+btn.addEventListener("click", async () => {
+  const label = btn.textContent;
+  try {
+    btn.disabled = true;
+    btn.textContent = "Running…";
+    await chrome.runtime.sendMessage({ type: "CLICK_TOGGLE_USERS" });
+  } catch (err) {
+    console.error("Error sending message to background:", err?.message || err);
+  } finally {
+    btn.textContent = label;
+    btn.disabled = false;
+    window.close();
+  }
+});
+
+// Init dropdown to current state
+document.addEventListener("DOMContentLoaded", async () => {
+  try {
+    const res = await chrome.runtime.sendMessage({ type: "GET_CURSOR_FIX_STATE" });
+    selectCursor.value = res?.enabled ? "on" : "off";
+  } catch (e) {
+    console.error("Failed to fetch cursor state:", e?.message || e);
+  }
+});
+
+// Update on change
+selectCursor.addEventListener("change", async () => {
+  const enabled = selectCursor.value === "on";
+  try {
+    await chrome.runtime.sendMessage({ type: "SET_CURSOR_FIX_STATE", enabled });
+  } catch (e) {
+    console.error("Failed to set cursor state:", e?.message || e);
+  }
+});


### PR DESCRIPTION
- Add checkbox in popup to toggle Fixed Fee Plugin (default OFF)
- Create orange banner at top of viewport with cost extraction
- Extract estimated costs using data-testid and fallback strategies
- Support multi-currency formatting (€, £, $) with proper parsing
- Real-time percentage calculations with 45% default margin
- DOM monitoring with MutationObserver for dynamic updates
- Proper cleanup and error handling for missing cost elements
- Left-aligned banner layout with input controls and displays

🤖 Generated with [Claude Code](https://claude.ai/code)