### PR TITLE
Replace dynamic calculations with manual Calculate buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,10 @@
 # Rules of engagement
 - Always give me a plan before making change so I can verify it.
+- For new feature branches, ask me for the feature name if I don't give it.
 
 # Shortcuts
 - If I type any of the following, translate it to the associated command:
-  - cpp: Commit the code, push it to a feature branch and create a pull request for me to review.
+  - cpp: Commit the code, push it to a feature branch and create a pull request for me to review. Always give a detailed commit message
 
 # Kantata Chrome Plugin
 

--- a/feature_designs/01_project-overview-estimate-calculator
+++ b/feature_designs/01_project-overview-estimate-calculator
@@ -17,11 +17,12 @@ This Chrome extension feature adds a persistent banner that displays project cos
 
 ### 3.1 Banner Positioning & Styling
 - **Position**: Fixed at top of browser viewport
-- **Z-index**: High value to ensure visibility above all page content
-- **Background**: Bright orange color theme
+- **Z-index**: High value (10000) to ensure visibility above all page content
+- **Background**: Orange gradient (`linear-gradient(135deg, #ff8c00 0%, #ff7f00 100%)`)
 - **Width**: Full viewport width
-- **Height**: Auto-adjust to content
-- **Layout**: Horizontal arrangement of elements
+- **Height**: Auto-adjust to content (approx. 48px)
+- **Layout**: Left-aligned horizontal arrangement with 20px gaps
+- **Body Adjustment**: Automatically adds top margin to prevent content overlap
 
 ### 3.2 Banner Visibility
 - **Show Condition**: Plugin checkbox is enabled
@@ -62,23 +63,25 @@ This Chrome extension feature adds a persistent banner that displays project cos
 
 ### 5.2 Percentage Input Control
 - **Type**: HTML number input with spinner controls
-- **Range**: -100% to +100%
+- **Range**: Unlimited (no min/max constraints in final implementation)
 - **Default Value**: 45%
-- **Decimal Support**: Yes (e.g., 10.5%)
+- **Step Size**: 1% (integer values)
 - **Input Methods**:
   - Manual text entry
-  - Increment/decrement buttons (step: 0.1%)
+  - Increment/decrement buttons
   - Keyboard up/down arrows
-- **Position**: Center of banner
+- **Position**: Left-center of banner (within input section)
 - **Label**: "Margin %:"
+- **Styling**: 80px width, white background with orange border focus
 
 ### 5.3 Calculated Fee Display
 - **Label**: "Estimated Fee with Margin:"
 - **Calculation**: `Estimated Cost × (1 + Percentage/100)`
 - **Rounding**: Round to nearest whole number
 - **Format**: Same currency format as original (symbol, thousand separators)
-- **Position**: Right side of banner
+- **Position**: Right side of banner (display-only span)
 - **Update Trigger**: Real-time as percentage changes
+- **Styling**: Bold font weight, larger font size for emphasis
 
 ## 6. Calculation Examples
 
@@ -101,8 +104,10 @@ This Chrome extension feature adds a persistent banner that displays project cos
 
 ### 8.1 DOM Monitoring
 - **Observer**: MutationObserver to detect page changes
-- **Scope**: Monitor changes to cost summary section
-- **Performance**: Debounce updates to prevent excessive recalculation
+- **Scope**: Monitor entire document body with subtree observation
+- **Performance**: Debounce updates (500ms) to prevent excessive recalculation
+- **Triggers**: childList changes and characterData changes containing currency symbols
+- **Cleanup**: Proper disconnect on banner removal
 
 ### 8.2 Data Persistence
 - **Session Scope**: No persistence between page loads
@@ -111,8 +116,10 @@ This Chrome extension feature adds a persistent banner that displays project cos
 
 ### 8.3 Browser Compatibility
 - **Target**: Chrome extension manifest v3
-- **CSS**: Use standard CSS properties for broad compatibility
-- **JavaScript**: ES6+ features acceptable for Chrome extension context
+- **CSS**: Standard CSS with modern features (backdrop-filter, gradients)
+- **JavaScript**: ES6+ features (arrow functions, destructuring, template literals)
+- **APIs Used**: chrome.scripting, chrome.storage.sync, chrome.tabs
+- **Injection Method**: Dynamic CSS and JS injection via scripting API
 
 ## 9. User Experience Requirements
 
@@ -143,24 +150,42 @@ This Chrome extension feature adds a persistent banner that displays project cos
 - [ ] Multiple tabs with different cost values
 - [ ] Rapid percentage changes (performance)
 
-## 11. Implementation Priority
+## 11. Implementation Status
 
-### Phase 1: Core Functionality
-1. Basic banner display
-2. Cost value extraction
-3. Percentage input control
-4. Calculation logic
+### ✅ Completed Features
+1. ✅ **Core Functionality**
+   - Banner display with orange gradient styling
+   - Cost value extraction with dual strategy (testid + fallback)
+   - Percentage input control with real-time updates
+   - Calculation logic with proper rounding
 
-### Phase 2: Enhanced Features
-1. Multi-currency support
-2. Error handling
-3. Visual feedback states
+2. ✅ **Enhanced Features**
+   - Multi-currency support (€, £, $) with intelligent parsing
+   - Error handling with user-friendly messages
+   - Visual feedback states (loading, error, success)
+   - DOM monitoring with debounced performance optimization
 
-### Phase 3: Polish & Testing
-1. Accessibility improvements
-2. Performance optimization
-3. Comprehensive testing
+3. ✅ **Integration & Polish**
+   - Chrome extension popup integration with storage sync
+   - Left-aligned banner layout as requested
+   - Proper cleanup and memory management
+   - Body margin adjustment to prevent content overlap
+
+### 📂 Implementation Files
+- `fixed-fee-banner.css` - Banner styling with orange gradient theme
+- `fixed-fee-banner.js` - Cost extraction, calculation, and DOM monitoring logic
+- `background.js` - Chrome extension integration and script injection
+- `popup.html` + `popup.js` - User interface toggle controls
+
+### 🧪 Testing Status
+All core functionality implemented and ready for user testing:
+- [✅] Plugin toggle enables/disables banner
+- [✅] Cost extraction works with testid and fallback strategies
+- [✅] Real-time percentage calculations with 45% default
+- [✅] Multi-currency support with proper formatting
+- [✅] Error handling for missing cost elements
+- [✅] DOM monitoring with performance optimization
 
 ---
 
-*This technical requirements document provides the foundation for implementing the "Activate Fixed Fee Plugin" feature. Please review and confirm if any adjustments are needed before development begins.*
+*This technical requirements document has been updated to reflect the completed implementation of the "Activate Fixed Fee Plugin" feature. The feature is now ready for testing and deployment.*

--- a/fixed-fee-banner.css
+++ b/fixed-fee-banner.css
@@ -50,7 +50,7 @@
   backdrop-filter: blur(10px);
 }
 
-#fixed-fee-percentage {
+#fixed-fee-percentage, #calculated-fee-input {
   width: 80px;
   padding: 6px 8px;
   border: 1px solid rgba(255,255,255,0.3);
@@ -62,10 +62,57 @@
   text-align: center;
 }
 
-#fixed-fee-percentage:focus {
+#calculated-fee-input {
+  width: 120px;
+}
+
+#fixed-fee-percentage:focus, #calculated-fee-input:focus {
   outline: 2px solid rgba(255,255,255,0.8);
   outline-offset: 1px;
   background: white;
+}
+
+#calculated-fee-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: rgba(255,255,255,0.5);
+}
+
+.calculate-btn {
+  padding: 4px 8px;
+  border: 1px solid rgba(255,255,255,0.4);
+  border-radius: 4px;
+  background: rgba(255,255,255,0.2);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  backdrop-filter: blur(5px);
+  white-space: nowrap;
+}
+
+.calculate-btn:hover {
+  background: rgba(255,255,255,0.3);
+  border-color: rgba(255,255,255,0.6);
+  transform: translateY(-1px);
+}
+
+.calculate-btn:active {
+  transform: translateY(0);
+  background: rgba(255,255,255,0.1);
+}
+
+.calculate-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.calculate-btn:disabled:hover {
+  background: rgba(255,255,255,0.2);
+  border-color: rgba(255,255,255,0.4);
+  transform: none;
 }
 
 .fixed-fee-error {


### PR DESCRIPTION
- Convert fee display to editable input field for bidirectional editing
- Add "Calculate Fee" button beside Margin % input to trigger fee calculation
- Add "Calculate Margin" button beside Fee input to trigger percentage calculation
- Remove automatic input event listeners that interfered with typing
- Style buttons with translucent orange theme and hover effects
- Implement proper disabled states for buttons when cost extraction fails
- Add loop prevention with isUpdating flag for bidirectional calculations
- Update CSS with button styling including backdrop blur effects

This resolves the dynamic interference issue where typing in fee field would immediately trigger reverse calculations, making it impossible to enter values. Users now have explicit control over when calculations occur.

🤖 Generated with [Claude Code](https://claude.ai/code)