### PR TITLE
Update cursor line feature to use orange color and restrict to /resou…

### DIFF
--- a/cursor-line-on.js
+++ b/cursor-line-on.js
@@ -9,7 +9,7 @@
         position: "fixed",
         width: "2px",
         height: "500px",
-        background: "#18b389",
+        background: "orange",
         pointerEvents: "none",
         zIndex: "2147483647",
         left: "0px",

--- a/feature_designs/02_cursor-line-resourcing.md
+++ b/feature_designs/02_cursor-line-resourcing.md
@@ -1,0 +1,24 @@
+# Kantata Chrome Plugin Features
+
+## Feature: Red Vertical Cursor Line
+
+**Trigger:** Popup checkbox (default: enabled)  
+**Scope:** `/resourcing` pages only (case-insensitive URL matching)  
+**Target Selector:** `div[role="presentation"]`  
+
+**Behavior:**
+- Shows a 2px orange vertical line centered on cursor (24px tall)
+- Only appears when hovering inside elements with `role="presentation"`
+- Line follows cursor movement and disappears when leaving target elements
+- Auto-applies on page load/refresh for `/resourcing` URLs
+
+**Implementation Notes:**
+- Uses chrome.scripting.executeScript to inject cursor-line-on.js/cursor-line-off.js
+- State persisted via chrome.storage.sync
+- Idempotent setup prevents duplicate listeners
+- Proper cleanup when disabled
+
+**Files:**
+- cursor-line-on.js: Creates orange line element and mouse event handlers
+- cursor-line-off.js: Removes line and cleans up event handlers
+


### PR DESCRIPTION
…rcing pages

- Change cursor line color from green (#18b389) to orange in cursor-line-on.js
- Confirm URL restriction to /resourcing pages is already implemented in background.js
- Create comprehensive feature documentation in 02_cursor-line-resourcing.md
- Document 2px orange vertical line behavior within div[role="presentation"] elements

This enhancement improves visual distinction and ensures the feature only activates on relevant Kantata resourcing pages as requested.

🤖 Generated with [Claude Code](https://claude.ai/code)